### PR TITLE
PHP7.4 support:

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "markdown2html"
   ],
   "require": {
-    "erusev/parsedown-extra": "^0.7.1"
+    "php": "~7.3",
+    "erusev/parsedown-extra": "^0.8.1"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
With php7.4 we're getting this notice now:

```
PHP Notice:  Trying to access array offset on value of type null in vendor/erusev/parsedown-extra/ParsedownExtra.php on line 241```

The issue was fixed in: http://github.com/erusev/parsedown-extra/pull/135